### PR TITLE
#3 persisted first-seen ordering for dashboard rows

### DIFF
--- a/claude_alerts/dashboard.py
+++ b/claude_alerts/dashboard.py
@@ -233,10 +233,10 @@ class Dashboard:
 
     def _build_lines(self, width: int) -> str:
         rl = self._cached_limits
-        sessions = sorted(
-            self.store.all(),
-            key=lambda s: (s.status != Status.WORKING, -s.last_event_at),
-        )
+        # Sort by first_seen_at ascending so a row's position is stable across
+        # status flips (WORKING ↔ WAITING) and event refreshes — once a session
+        # registers, it stays where it is until it ends.
+        sessions = sorted(self.store.all(), key=lambda s: s.first_seen_at)
         rule = "─" * min(width, 100)
         lines: list[str] = []
         lines.append(self._header(rl, len(sessions)))

--- a/claude_alerts/persistence.py
+++ b/claude_alerts/persistence.py
@@ -32,22 +32,29 @@ def _session_to_dict(s: Session) -> dict:
         "background_active": s.background_active,
         "bound_window_id": s.bound_window_id,
         "client_window_id": s.client_window_id,
+        "first_seen_at": s.first_seen_at,
     }
 
 
 def _dict_to_session(d: dict) -> Optional[Session]:
     """Reconstruct a Session from a persisted dict. Returns None on shape errors."""
     try:
+        last_event_at = float(d["last_event_at"])
+        # Pre-#3 bindings files don't carry first_seen_at — fall back to
+        # last_event_at so existing sessions still get a plausible
+        # appearance timestamp for the dashboard sort.
+        first_seen_at = float(d["first_seen_at"]) if "first_seen_at" in d else last_event_at
         return Session(
             session_id=str(d["session_id"]),
             cwd=str(d["cwd"]),
             claude_pid=int(d["claude_pid"]),
             status=Status(d["status"]),
-            last_event_at=float(d["last_event_at"]),
+            last_event_at=last_event_at,
             bound_window_id=int(d["bound_window_id"]) if d.get("bound_window_id") is not None else None,
             client_window_id=int(d["client_window_id"]) if d.get("client_window_id") is not None else None,
             last_event=str(d.get("last_event", "")),
             background_active=bool(d.get("background_active", False)),
+            first_seen_at=first_seen_at,
         )
     except (KeyError, TypeError, ValueError) as e:
         log.warning("persisted session entry rejected: %s (%r)", e, d)

--- a/claude_alerts/sessions.py
+++ b/claude_alerts/sessions.py
@@ -62,6 +62,10 @@ class Session:
     client_window_id: Optional[int] = None
     last_event: str = ""
     background_active: bool = False
+    # Wall-clock timestamp of the first event we observed for this session.
+    # Stable for the life of the session and used as the dashboard sort key
+    # so a row's position doesn't jump when status flips.
+    first_seen_at: float = 0.0
 
 
 class SessionStore:
@@ -122,6 +126,7 @@ class SessionStore:
                 status=new_status,
                 last_event_at=evt.timestamp,
                 last_event=evt.event,
+                first_seen_at=evt.timestamp,
             )
             self._sessions[evt.session_id] = session
             changed = True

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -307,6 +307,54 @@ def test_dashboard_renders_em_dash_when_no_contexts_data(tmp_path):
     assert "—" in text
 
 
+def test_dashboard_sorts_sessions_by_first_seen_at_ascending(tmp_path):
+    """Once a session registers, it sits at the row determined by its
+    first_seen_at. Earlier sessions are higher in the list."""
+    store = SessionStore()
+    # Insert "late" first, then "early" — order of insertion must not matter.
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="late0001-x", cwd="/work",
+        claude_pid=1, timestamp=200.0,
+    ))
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="early001-x", cwd="/work",
+        claude_pid=1, timestamp=100.0,
+    ))
+    d = Dashboard(store, sidecar_path=tmp_path / "absent.json", force_render=True)
+    text = d.render_string()
+    rows = [r for r in text.splitlines() if "/work" in r]
+    assert len(rows) == 2
+    assert "early001" in rows[0]
+    assert "late0001" in rows[1]
+
+
+def test_dashboard_row_position_stable_across_status_flip(tmp_path):
+    """Acceptance criterion: a session flipping WORKING ↔ WAITING does
+    not change its row position. Under the old (status-first) sort, the
+    later session would jump to the top when it became WORKING."""
+    store = SessionStore()
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="early001-x", cwd="/work",
+        claude_pid=1, timestamp=100.0,
+    ))
+    store.apply_event(ClaudeEvent(
+        event="Stop", session_id="late0001-x", cwd="/work",
+        claude_pid=1, timestamp=200.0,
+    ))
+    d = Dashboard(store, sidecar_path=tmp_path / "absent.json", force_render=True)
+    rows_before = [r for r in d.render_string().splitlines() if "/work" in r]
+
+    # late0001 flips WAITING → WORKING. Old sort would move it above early001.
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="late0001-x", cwd="/work",
+        claude_pid=1, timestamp=300.0,
+    ))
+    rows_after = [r for r in d.render_string().splitlines() if "/work" in r]
+
+    assert "early001" in rows_before[0] and "late0001" in rows_before[1]
+    assert "early001" in rows_after[0] and "late0001" in rows_after[1]
+
+
 def test_dashboard_session_block_keeps_cwd_aligned(tmp_path):
     """Mixed rows (one with data, one without) — CWD column stays at the same
     horizontal position so the table stays readable."""

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -21,6 +21,7 @@ def _make_session(
     session_id: str = "s1",
     bound: int | None = 0xFF22,
     client: int | None = 0xCC11,
+    first_seen_at: float = 1.0,
 ) -> Session:
     return Session(
         session_id=session_id,
@@ -32,6 +33,7 @@ def _make_session(
         client_window_id=client,
         last_event="UserPromptSubmit",
         background_active=False,
+        first_seen_at=first_seen_at,
     )
 
 
@@ -79,6 +81,7 @@ def test_load_round_trips_all_fields(tmp_path):
         client_window_id=0x200,
         last_event="PermissionRequest",
         background_active=True,
+        first_seen_at=10.0,
     )
     p.save([original])
     _settle(p)
@@ -96,6 +99,7 @@ def test_load_round_trips_all_fields(tmp_path):
     assert s.client_window_id == 0x200
     assert s.last_event == "PermissionRequest"
     assert s.background_active is True
+    assert s.first_seen_at == 10.0
 
 
 def test_load_missing_file_returns_empty(tmp_path):
@@ -150,6 +154,35 @@ def test_load_skips_individual_bad_entries(tmp_path):
     p = BindingPersister(path)
     loaded = p.load()
     assert [s.session_id for s in loaded] == ["good"]
+
+
+def test_load_missing_first_seen_at_falls_back_to_last_event_at(tmp_path):
+    """Pre-#3 bindings files don't carry first_seen_at. Loading them must
+    not raise — fall back to last_event_at so existing sessions retain a
+    plausible appearance timestamp for the dashboard sort."""
+    path = tmp_path / "sessions.json"
+    path.write_text(json.dumps({
+        "version": SCHEMA_VERSION,
+        "saved_at": 0,
+        "sessions": [
+            {
+                "session_id": "old",
+                "cwd": "/p",
+                "claude_pid": 1,
+                "status": "waiting",
+                "last_event_at": 12.5,
+                "last_event": "Stop",
+                "background_active": False,
+                "bound_window_id": 0xFF,
+                "client_window_id": 0xFF,
+                # NOTE: no first_seen_at
+            },
+        ],
+    }))
+    p = BindingPersister(path)
+    loaded = p.load()
+    assert len(loaded) == 1
+    assert loaded[0].first_seen_at == 12.5
 
 
 def test_save_writes_file_with_0600_permissions(tmp_path):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -208,6 +208,25 @@ def test_one_buggy_listener_does_not_break_others():
     assert seen == ["s1"]
 
 
+def test_first_seen_at_set_on_creation():
+    """A newly created session records the wall-clock time it was first observed,
+    so the dashboard can sort rows by appearance order."""
+    store = SessionStore()
+    store.apply_event(evt("SessionStart", t=42.0))
+    assert store.get("s1").first_seen_at == 42.0
+
+
+def test_first_seen_at_unchanged_on_subsequent_events():
+    """first_seen_at is a stable identity for the session — last_event_at advances,
+    first_seen_at does not."""
+    store = SessionStore()
+    store.apply_event(evt("SessionStart", t=1.0))
+    store.apply_event(evt("UserPromptSubmit", t=99.0))
+    s = store.get("s1")
+    assert s.first_seen_at == 1.0
+    assert s.last_event_at == 99.0
+
+
 def test_apply_event_stamps_last_event():
     """Session.last_event records the name of the most recently applied event,
     so the overlay can distinguish Stop-WAITING from Notification-WAITING."""


### PR DESCRIPTION
## Summary

- Adds `Session.first_seen_at`, set from the first event's wall-clock timestamp at session creation.
- Dashboard now sorts sessions by `first_seen_at` ascending — row position is stable across WORKING ↔ WAITING flips and new events.
- Bindings file persistence round-trips the new field, with a fallback to `last_event_at` when loading pre-upgrade fixtures.

Closes #3.

## Test plan

- [x] `pytest` (locally green; CI workflow added in d0d2712 will re-run)
- [x] `tests/test_sessions.py::test_dashboard_row_position_stable_across_status_flip` — proves the regression this fixes is gone
- [x] `tests/test_persistence.py::test_load_missing_first_seen_at_falls_back_to_last_event_at` — proves pre-upgrade bindings load cleanly
- [x] `tests/test_persistence.py::test_load_round_trips_all_fields` — extended to cover the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)