### PR TITLE
#2 drop SESSION column from dashboard

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -66,8 +66,8 @@ get forgotten.
   `IDLE_SWEEP_INTERVAL_S` / `IDLE_MAX_AGE_S` in `daemon.py:26-27`,
   `SIDECAR_STALE_AFTER_S` in `dashboard.py`, `BACKGROUND_TASK_TOOLS` and
   `TERMINAL_WM_CLASSES` lists.
-- `_short_cwd` and `_short_id` use byte-length, not visible width.
-  Multibyte / wide CJK / emoji paths render ragged but don't crash.
+- `_short_cwd` uses byte-length, not visible width. Multibyte / wide
+  CJK / emoji paths render ragged but don't crash.
 - `evict_idle` mixes `time.time()` (wall-clock) and `time.monotonic()`.
   Wall-clock leaps survive but could surprise.
 - `--verbose` / `-v` CLI flag for stderr logging (currently only

--- a/claude_alerts/dashboard.py
+++ b/claude_alerts/dashboard.py
@@ -61,10 +61,6 @@ def _strip_control(s: str) -> str:
     return _CONTROL_CHARS.sub("?", s)
 
 
-def _short_id(session_id: str) -> str:
-    return _strip_control(session_id.split("-", 1)[0])
-
-
 def _short_cwd(cwd: str, max_chars: int = 50) -> str:
     cwd = _strip_control(cwd)
     home = str(Path.home())
@@ -290,11 +286,10 @@ class Dashboard:
         if not sessions:
             return ["  no active sessions."]
         # CTX column is fixed-width 16 (see _format_ctx).
-        rows = [f"  SESSION   STATUS     {'CTX':<16}  CWD"]
+        rows = [f"  STATUS     {'CTX':<16}  CWD"]
         for s in sessions:
-            sid = _short_id(s.session_id)
             cwd = _short_cwd(s.cwd)
             cu = contexts.load(s.session_id, self.contexts_dir)
             ctx = _format_ctx(cu)
-            rows.append(f"  {sid:<8}  {_status_marker(s.status):<9}  {ctx}  {cwd}")
+            rows.append(f"  {_status_marker(s.status):<9}  {ctx}  {cwd}")
         return rows

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -14,7 +14,6 @@ from claude_alerts.dashboard import (
     _format_ctx,
     _format_resets_in,
     _short_cwd,
-    _short_id,
     _short_tokens,
 )
 from claude_alerts.events import ClaudeEvent
@@ -25,10 +24,6 @@ def _write_sidecar(tmp_path: Path, payload: dict) -> Path:
     p = tmp_path / "rate_limits.json"
     p.write_text(json.dumps(payload))
     return p
-
-
-def test_short_id_takes_uuid_prefix():
-    assert _short_id("5756986d-da80-4494-af8d-35dccc263499") == "5756986d"
 
 
 def test_short_cwd_substitutes_home(monkeypatch, tmp_path):
@@ -115,9 +110,26 @@ def test_dashboard_lists_active_session(tmp_path):
     ))
     d = Dashboard(store, sidecar_path=tmp_path / "absent.json", force_render=True)
     text = d.render_string()
-    assert "abc12345" in text
+    # Session-id hash is no longer rendered in the dashboard (#2).
+    assert "abc12345" not in text
     assert "1 session" in text
     assert "● working" in text
+
+
+def test_dashboard_session_header_omits_session_column(tmp_path):
+    """Header is `STATUS     CTX               CWD` — no SESSION column (#2)."""
+    store = SessionStore()
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="abc12345-x", cwd=str(tmp_path),
+        claude_pid=1, timestamp=1.0,
+    ))
+    d = Dashboard(store, sidecar_path=tmp_path / "absent.json", force_render=True)
+    text = d.render_string()
+    header_lines = [line for line in text.splitlines() if "STATUS" in line and "CTX" in line]
+    assert len(header_lines) == 1
+    header = header_lines[0]
+    assert "SESSION" not in header
+    assert header.lstrip() == "STATUS     CTX               CWD"
 
 
 def test_dashboard_marks_data_stale_when_old(tmp_path):


### PR DESCRIPTION
Closes #2.

## Summary

- Drops the 8-char session-id hash column from the dashboard's session list.
- Header now reads `STATUS     CTX               CWD` (matches the issue spec exactly).
- Removes the now-dead `_short_id` helper and its unit test.

The session id remains visible in `daemon.log` (every event log line includes it) and in the bindings file, so it's still available for debugging.

## Acceptance criteria

- [x] Dashboard session-list rows no longer include the 8-char session-id hash.
- [x] Header reads `STATUS     CTX               CWD` (no SESSION column).
- [x] Existing dashboard test for session listing is updated; ANSI-strip test still passes.
- [x] Session id remains accessible in `daemon.log` and the bindings file.

## Test plan

- [x] `pytest tests/test_dashboard.py` — 27 passed.
- [x] `pytest tests/test_dashboard.py tests/test_sessions.py tests/test_persistence.py tests/test_contexts.py` — 99 passed.
- [x] Manual render check confirms the new header/row layout aligns and the sid hash is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)