### PR TITLE
#10 OpenClaw filter at hook layer

### DIFF
--- a/scripts/hooks/emit-event.sh
+++ b/scripts/hooks/emit-event.sh
@@ -5,6 +5,14 @@
 
 set -euo pipefail
 
+# OpenClaw filter: any OPENCLAW_* env var marks the Claude session as
+# agent-runtime-managed, so the daemon should never see its events (no
+# overlay, no dashboard row). Exit 0 silently — OpenClaw's spawn pipeline
+# expects success — and write nothing to the events directory.
+if [ -n "${!OPENCLAW_*}" ]; then
+    exit 0
+fi
+
 EVENT="${1:?event name required}"
 EVENTS_DIR="${CLAUDE_ALERTS_EVENTS_DIR:-$HOME/.local/state/claude-alerts/events}"
 mkdir -p -m 700 "$EVENTS_DIR"

--- a/tests/test_hook_script.py
+++ b/tests/test_hook_script.py
@@ -76,6 +76,69 @@ def test_hook_script_omits_tool_name_when_absent(tmp_path):
     assert "tool_name" not in data
 
 
+def _env_without_openclaw(tmp_path):
+    """Build a clean env that scrubs any inherited OPENCLAW_* vars from the
+    developer's shell, so tests don't accidentally trigger the OpenClaw filter."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OPENCLAW_")}
+    env["CLAUDE_ALERTS_EVENTS_DIR"] = str(tmp_path)
+    return env
+
+
+@pytest.mark.skipif(not has_jq(), reason="jq is required by the hook script")
+def test_hook_script_skips_when_openclaw_env_set(tmp_path):
+    """An OPENCLAW_* env var marks the session as OpenClaw-driven; the hook
+    must exit 0 silently and write nothing to the events dir."""
+    env = _env_without_openclaw(tmp_path)
+    env["OPENCLAW_AGENT_RUNTIME"] = "1"
+    payload = json.dumps({"session_id": "abc", "cwd": "/p"})
+    result = subprocess.run(
+        ["bash", str(HOOK_SCRIPT), "PreToolUse"],
+        input=payload, text=True, env=env,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(not has_jq(), reason="jq is required by the hook script")
+def test_hook_script_skips_for_any_openclaw_suffix(tmp_path):
+    """The filter triggers on the OPENCLAW_ prefix regardless of suffix."""
+    env = _env_without_openclaw(tmp_path)
+    env["OPENCLAW_MCP_TOKEN"] = "secret"
+    subprocess.run(
+        ["bash", str(HOOK_SCRIPT), "Stop"],
+        input='{"session_id":"x","cwd":"/y"}', text=True, env=env, check=True,
+    )
+    assert list(tmp_path.glob("*.json")) == []
+
+
+@pytest.mark.skipif(not has_jq(), reason="jq is required by the hook script")
+def test_hook_script_writes_event_when_no_openclaw_var(tmp_path):
+    """Negative path: with no OPENCLAW_* present, behavior is unchanged."""
+    env = _env_without_openclaw(tmp_path)
+    payload = json.dumps({"session_id": "abc", "cwd": "/p"})
+    subprocess.run(
+        ["bash", str(HOOK_SCRIPT), "PreToolUse"],
+        input=payload, text=True, env=env, check=True,
+    )
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+
+
+@pytest.mark.skipif(not has_jq(), reason="jq is required by the hook script")
+def test_hook_script_filter_does_not_match_lookalike_prefix(tmp_path):
+    """A var named OPENCLAWX (no underscore) must NOT trigger the filter —
+    we match the OPENCLAW_ prefix specifically, not a substring."""
+    env = _env_without_openclaw(tmp_path)
+    env["OPENCLAWX_THING"] = "1"
+    env["NOT_OPENCLAW_FOO"] = "1"
+    subprocess.run(
+        ["bash", str(HOOK_SCRIPT), "Stop"],
+        input='{"session_id":"x","cwd":"/y"}', text=True, env=env, check=True,
+    )
+    assert len(list(tmp_path.glob("*.json"))) == 1
+
+
 @pytest.mark.skipif(not has_jq(), reason="jq is required by the hook script")
 def test_hook_script_sanitizes_session_id_in_filename(tmp_path):
     """A hostile session_id with path-traversal characters must NOT escape


### PR DESCRIPTION
## Summary

- Hook script `emit-event.sh` now exits 0 silently when any `OPENCLAW_*` env var is present, so OpenClaw-driven Claude sessions never reach the daemon (no overlay, no dashboard row, no session record).
- Sessions opened normally (no `OPENCLAW_*` in env) behave exactly as before.
- `statusline.sh` is intentionally untouched, per the issue: rate-limit / CTX numbers continue to reflect total quota burn including OpenClaw sessions.

Closes #10.

## Test plan

- [x] `pytest tests/test_hook_script.py` — 9/9 green (5 existing + 4 new).
- [x] `pytest tests/test_statusline_sh.py` — sidecar tests unchanged, still green.
- [ ] Manual end-to-end smoke: requires a real OpenClaw spawn to verify no overlay appears. Deferred until #11 lands and there's a visible overlay-paint signal to check against.

## Acceptance criteria

- [x] OPENCLAW_* present → exit 0, no event file written.
- [x] OPENCLAW_* absent → unchanged behavior.
- [x] Hook test suite exercises both paths (positive, negative, alternate suffix, lookalike-prefix non-match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)