### PR TITLE
#11 focus-modulated border brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ sitting idle at `Stop`. Stays green during autonomous wake-ups (`Monitor`,
 `CronCreate`, `RemoteTrigger`, `ScheduleWakeup`) so you don't get a false
 "needs me" signal while a background task is alive.
 
+The border is also **modulated by focus**: only the currently-focused
+Claude terminal paints at full brightness — every other bound terminal
+dims its border to ¼ intensity. When focus moves to a non-Claude window
+(another app, the dashboard) all Claude borders go dim. This makes a
+single needs-me terminal jump out across a screen full of Claude sessions
+without any of them being individually loud.
+
 In the daemon's own terminal:
 
 ```

--- a/claude_alerts/colors.py
+++ b/claude_alerts/colors.py
@@ -1,0 +1,73 @@
+"""Pure colour utilities — no X11, no Xlib, easy to test in isolation.
+
+Two responsibilities:
+
+- ``dim_hex(hex_str, ratio)`` derives a dimmer shade from a focused colour.
+- ``pick_color_pixel(...)`` is the single source of truth for which pixel a
+  bound overlay should paint, given session state and focus. The overlay
+  manager wraps this with the actual session-to-state translation.
+"""
+from __future__ import annotations
+
+from claude_alerts.sessions import Status
+
+# Events whose arrival means the user must take action before Claude can
+# continue — the overlay paints the WAITING colour even when a background
+# task is alive. Imported here (instead of from sessions) to keep this
+# module's policy self-contained.
+_USER_ACTION_EVENTS = frozenset({
+    "Notification",
+    "PermissionRequest",
+    "Elicitation",
+})
+
+
+def dim_hex(hex_str: str, ratio: float) -> str:
+    """Return a dimmer hex colour derived from ``hex_str``.
+
+    Each RGB channel is multiplied by ``ratio`` clamped to ``[0, 1]``. The
+    output is always in lowercase ``#rrggbb`` form. Raises ``ValueError`` on
+    a malformed input string.
+    """
+    s = hex_str.lstrip("#")
+    if len(s) != 6:
+        raise ValueError(f"bad hex color: {hex_str!r}")
+    try:
+        r = int(s[0:2], 16)
+        g = int(s[2:4], 16)
+        b = int(s[4:6], 16)
+    except ValueError as e:
+        raise ValueError(f"bad hex color: {hex_str!r}") from e
+
+    clamped = max(0.0, min(1.0, ratio))
+    r = int(r * clamped)
+    g = int(g * clamped)
+    b = int(b * clamped)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def pick_color_pixel(
+    *,
+    status: Status,
+    last_event: str,
+    background_active: bool,
+    is_focused: bool,
+    working_pixel: int,
+    waiting_pixel: int,
+    working_dim_pixel: int,
+    waiting_dim_pixel: int,
+) -> int:
+    """Decide which X pixel a bound overlay should paint.
+
+    The status / background_active / last_event policy is exactly the one
+    that lived on ``OverlayManager.color_for`` before #11. Focus is layered
+    on top: focused windows paint the emissive pixel, unfocused ones paint
+    the dim variant.
+    """
+    if status == Status.WORKING:
+        return working_pixel if is_focused else working_dim_pixel
+
+    # status == WAITING from here.
+    if background_active and last_event not in _USER_ACTION_EVENTS:
+        return working_pixel if is_focused else working_dim_pixel
+    return waiting_pixel if is_focused else waiting_dim_pixel

--- a/claude_alerts/daemon.py
+++ b/claude_alerts/daemon.py
@@ -94,6 +94,13 @@ class Daemon:
 
     def run(self) -> None:
         self.x11.subscribe_root_substructure()
+        self.x11.subscribe_root_property_changes()
+        # Seed initial focus so the first paint after a restart reflects the
+        # current _NET_ACTIVE_WINDOW without waiting for the user to alt-tab.
+        try:
+            self.overlay.set_focused_window(self.x11.get_active_window_id())
+        except Exception:
+            log.exception("initial focus query failed")
 
         # Restore persisted bindings before subscribing to events, so the
         # first ingester event sees a fully reconstructed store. Drop entries
@@ -190,6 +197,17 @@ class Daemon:
             # binder.unbind_window calls store.set_bound_window(None) which fires
             # on_change which the overlay handles via _sync_one -> _destroy.
             self.binder.unbind_window(wid)
+        elif et == X.PropertyNotify:
+            # Only the _NET_ACTIVE_WINDOW property on root drives focus
+            # modulation. Anything else (window-name updates, GTK frame
+            # extents on other windows, etc.) we deliberately ignore so the
+            # overlay manager isn't woken on every keystroke.
+            if (
+                getattr(event, "atom", None) == self.x11._NET_ACTIVE_WINDOW
+                and getattr(event, "window", None) is not None
+                and event.window.id == self.x11.root.id
+            ):
+                self.overlay.set_focused_window(self.x11.get_active_window_id())
 
 
 def default_events_dir() -> Path:

--- a/claude_alerts/overlay.py
+++ b/claude_alerts/overlay.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
 from Xlib import X, Xatom
 from Xlib.ext import shape
 
+from claude_alerts.colors import dim_hex, pick_color_pixel
 from claude_alerts.config import Config
 from claude_alerts.sessions import (
     Session,
@@ -14,6 +16,10 @@ from claude_alerts.sessions import (
     USER_ACTION_EVENTS,
 )
 from claude_alerts.x11 import Geometry, X11Client
+
+# Ratio applied to focused colours to derive the unfocused/dim variant. #11
+# hard-codes 0.25; #12 will let users override per-state via config.toml.
+DIM_RATIO = 0.25
 
 log = logging.getLogger(__name__)
 
@@ -44,12 +50,19 @@ class _OverlayWindow:
         self.x11 = x11
         self.thickness = thickness
         self.color_pixel = color_pixel
+        self.window_id: Optional[int] = None
         self.win = x11.screen.root.create_window(
             target_geo.x, target_geo.y, target_geo.width, target_geo.height, 0,
             X.CopyFromParent, X.InputOutput, X.CopyFromParent,
             background_pixel=color_pixel,
             event_mask=X.ExposureMask,
         )
+        # Cache the X server's id so the manager can filter focus events
+        # whose target is one of our own overlay windows.
+        try:
+            self.window_id = int(self.win.id)
+        except Exception:
+            self.window_id = None
         self._apply_shape(target_geo)
         # Set WM hints so the overlay stacks with its terminal, has no
         # decorations, and stays out of taskbar / alt-tab.
@@ -127,23 +140,64 @@ class OverlayManager:
         self._overlays: dict[str, _OverlayWindow] = {}
         self._working_pixel = _rgb_to_pixel(hex_to_rgb(config.color_working))
         self._waiting_pixel = _rgb_to_pixel(hex_to_rgb(config.color_waiting))
+        self._working_dim_pixel = _rgb_to_pixel(
+            hex_to_rgb(dim_hex(config.color_working, DIM_RATIO))
+        )
+        self._waiting_dim_pixel = _rgb_to_pixel(
+            hex_to_rgb(dim_hex(config.color_waiting, DIM_RATIO))
+        )
+        # Currently-focused client window id (per _NET_ACTIVE_WINDOW). None
+        # when no Claude or other window is focused; daemon queries the
+        # X server at startup so this reflects reality before the first paint.
+        self._focused_client_id: Optional[int] = None
+        # X11 ids of overlay windows we have created. Used to filter
+        # _NET_ACTIVE_WINDOW updates that target our own overlays — those
+        # would otherwise dim every Claude border whenever a new overlay maps.
+        self._overlay_window_ids: set[int] = set()
         store.on_change(self.on_session_changed)
 
-    def color_for(self, session: Session) -> int:
+    def color_for(self, session: Session, *, is_focused: bool = True) -> int:
         """Pick the overlay color for a session.
 
-        Green when Claude is actively WORKING, or when the session has an
-        autonomous wake-up alive (background_active) and the most recent
-        event was not a user-action event. User-action events (Notification,
-        PermissionRequest) always paint red, because they mean the user
-        must act, even if a background task is also alive.
+        ``is_focused`` defaults to True so callers that don't track focus
+        (older tests, third-party code) keep the pre-#11 emissive behaviour.
         """
-        if session.status == Status.WORKING:
-            return self._working_pixel
-        # status == WAITING from here.
-        if session.background_active and session.last_event not in USER_ACTION_EVENTS:
-            return self._working_pixel
-        return self._waiting_pixel
+        return pick_color_pixel(
+            status=session.status,
+            last_event=session.last_event,
+            background_active=session.background_active,
+            is_focused=is_focused,
+            working_pixel=self._working_pixel,
+            waiting_pixel=self._waiting_pixel,
+            working_dim_pixel=self._working_dim_pixel,
+            waiting_dim_pixel=self._waiting_dim_pixel,
+        )
+
+    def _is_focused(self, session: Session) -> bool:
+        cid = session.client_window_id
+        if cid is None:
+            return False
+        return self._focused_client_id == cid
+
+    def set_focused_window(self, window_id: Optional[int]) -> None:
+        """Update the currently-focused client window.
+
+        Called by the daemon mainloop on _NET_ACTIVE_WINDOW PropertyNotify
+        and once at startup. Repaints every bound overlay through the pure
+        colour-policy function. Filters out focus events targeting one of
+        our own overlay windows (which can fire briefly when a new overlay
+        maps) and coalesces no-op updates.
+        """
+        if window_id is not None and window_id in self._overlay_window_ids:
+            return
+        if self._focused_client_id == window_id:
+            return
+        self._focused_client_id = window_id
+        for session in self.store.all():
+            ov = self._overlays.get(session.session_id)
+            if ov is None:
+                continue
+            ov.set_color(self.color_for(session, is_focused=self._is_focused(session)))
 
     def on_session_changed(self, session_id: str) -> None:
         session = self.store.get(session_id)
@@ -206,12 +260,16 @@ class OverlayManager:
             self._destroy(session.session_id)
             return
         existing = self._overlays.get(session.session_id)
-        color_pixel = self.color_for(session)
+        color_pixel = self.color_for(session, is_focused=self._is_focused(session))
         if existing is None:
-            self._overlays[session.session_id] = _OverlayWindow(
+            new_ov = _OverlayWindow(
                 self.x11, geo, color_pixel, self.config.border_thickness_px,
                 transient_for_window_id=session.bound_window_id,
             )
+            self._overlays[session.session_id] = new_ov
+            wid = getattr(new_ov, "window_id", None)
+            if wid is not None:
+                self._overlay_window_ids.add(wid)
         else:
             existing.update_geometry(geo)
             existing.set_color(color_pixel)
@@ -219,4 +277,7 @@ class OverlayManager:
     def _destroy(self, session_id: str) -> None:
         ov = self._overlays.pop(session_id, None)
         if ov is not None:
+            wid = getattr(ov, "window_id", None)
+            if wid is not None:
+                self._overlay_window_ids.discard(wid)
             ov.destroy()

--- a/claude_alerts/x11.py
+++ b/claude_alerts/x11.py
@@ -140,7 +140,22 @@ class X11Client:
 
     def subscribe_root_substructure(self) -> None:
         """Receive ConfigureNotify and DestroyNotify for all top-level windows."""
-        self.root.change_attributes(event_mask=X.SubstructureNotifyMask)
+        self.root.change_attributes(
+            event_mask=X.SubstructureNotifyMask | X.PropertyChangeMask
+        )
+        self.display.flush()
+
+    def subscribe_root_property_changes(self) -> None:
+        """Receive PropertyNotify on the root window — used to track
+        ``_NET_ACTIVE_WINDOW`` changes for focus modulation.
+
+        Calling this after :meth:`subscribe_root_substructure` is harmless;
+        change_attributes replaces the mask, so this method ORs the
+        substructure mask back in so neither subscription cancels the other.
+        """
+        self.root.change_attributes(
+            event_mask=X.SubstructureNotifyMask | X.PropertyChangeMask
+        )
         self.display.flush()
 
     def get_frame_window_id(self, client_window_id: int) -> Optional[int]:

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,151 @@
+"""Pure-function tests for colour dimming and the focus-aware policy picker."""
+from __future__ import annotations
+
+import pytest
+
+from claude_alerts.colors import dim_hex, pick_color_pixel
+from claude_alerts.sessions import Status
+
+
+# -------------------------- dim_hex --------------------------
+
+
+def test_dim_hex_ratio_one_is_identity():
+    assert dim_hex("#ff0000", 1.0) == "#ff0000"
+    assert dim_hex("#22c55e", 1.0) == "#22c55e"
+
+
+def test_dim_hex_ratio_zero_is_black():
+    assert dim_hex("#ff0000", 0.0) == "#000000"
+    assert dim_hex("#22c55e", 0.0) == "#000000"
+
+
+def test_dim_hex_half_halves_each_channel():
+    # int-truncates toward zero per channel:
+    # 0xff = 255 * 0.5 = 127.5 -> 127 = 0x7f
+    # 0x80 = 128 * 0.5 = 64.0  -> 64  = 0x40
+    # 0x40 = 64  * 0.5 = 32.0  -> 32  = 0x20
+    assert dim_hex("#ff0000", 0.5) == "#7f0000"
+    assert dim_hex("#80ff40", 0.5) == "#407f20"
+
+
+def test_dim_hex_quarter_for_default_dim_ratio():
+    # 0x22 * 0.25 = 8.5 -> 8 = 0x08
+    # 0xc5 * 0.25 = 49.25 -> 49 = 0x31
+    # 0x5e * 0.25 = 23.5 -> 23 = 0x17
+    assert dim_hex("#22c55e", 0.25) == "#083117"
+
+
+def test_dim_hex_accepts_no_leading_hash():
+    assert dim_hex("ff0000", 1.0) == "#ff0000"
+
+
+def test_dim_hex_clamps_ratio_above_one():
+    # Out-of-range ratios clamp into [0, 1] rather than producing > 0xff channels.
+    assert dim_hex("#808080", 5.0) == "#808080"
+
+
+def test_dim_hex_clamps_negative_ratio():
+    assert dim_hex("#808080", -0.5) == "#000000"
+
+
+def test_dim_hex_rejects_bad_hex():
+    with pytest.raises(ValueError):
+        dim_hex("#zzz000", 0.5)
+    with pytest.raises(ValueError):
+        dim_hex("#abcde", 0.5)  # 5 chars
+    with pytest.raises(ValueError):
+        dim_hex("", 0.5)
+
+
+# -------------------------- pick_color_pixel --------------------------
+#
+# The policy mirrors the pre-#11 OverlayManager.color_for logic, plus a
+# focus dimension. The four pixel arguments are arbitrary integer sentinels
+# for testing — the function is just a multi-way switch returning one of them.
+
+W = 0xAA0001       # working
+WD = 0xAA0002      # working_dim
+R = 0xBB0001       # waiting
+RD = 0xBB0002      # waiting_dim
+
+
+def _pick(*, status, last_event="", background_active=False, is_focused=True):
+    return pick_color_pixel(
+        status=status,
+        last_event=last_event,
+        background_active=background_active,
+        is_focused=is_focused,
+        working_pixel=W,
+        waiting_pixel=R,
+        working_dim_pixel=WD,
+        waiting_dim_pixel=RD,
+    )
+
+
+def test_pick_working_focused_is_working():
+    assert _pick(status=Status.WORKING, last_event="UserPromptSubmit") == W
+
+
+def test_pick_working_unfocused_is_working_dim():
+    assert _pick(status=Status.WORKING, last_event="UserPromptSubmit", is_focused=False) == WD
+
+
+def test_pick_waiting_focused_is_waiting():
+    assert _pick(status=Status.WAITING, last_event="Stop") == R
+
+
+def test_pick_waiting_unfocused_is_waiting_dim():
+    assert _pick(status=Status.WAITING, last_event="Stop", is_focused=False) == RD
+
+
+def test_pick_waiting_with_background_active_is_working_when_focused():
+    """Stop after Monitor: stays green (working) while focused."""
+    assert _pick(
+        status=Status.WAITING,
+        last_event="Stop",
+        background_active=True,
+    ) == W
+
+
+def test_pick_waiting_with_background_active_is_working_dim_when_unfocused():
+    assert _pick(
+        status=Status.WAITING,
+        last_event="Stop",
+        background_active=True,
+        is_focused=False,
+    ) == WD
+
+
+def test_pick_notification_with_background_active_is_waiting_when_focused():
+    """User-action event overrides green-during-pause."""
+    assert _pick(
+        status=Status.WAITING,
+        last_event="Notification",
+        background_active=True,
+    ) == R
+
+
+def test_pick_notification_with_background_active_is_waiting_dim_when_unfocused():
+    assert _pick(
+        status=Status.WAITING,
+        last_event="Notification",
+        background_active=True,
+        is_focused=False,
+    ) == RD
+
+
+def test_pick_permission_request_with_background_active_is_waiting_when_focused():
+    assert _pick(
+        status=Status.WAITING,
+        last_event="PermissionRequest",
+        background_active=True,
+    ) == R
+
+
+def test_pick_elicitation_with_background_active_is_waiting_when_focused():
+    assert _pick(
+        status=Status.WAITING,
+        last_event="Elicitation",
+        background_active=True,
+    ) == R

--- a/tests/test_daemon_binding_trigger.py
+++ b/tests/test_daemon_binding_trigger.py
@@ -47,6 +47,8 @@ class _NoopX11:
         pass
     def subscribe_root_substructure(self):
         pass
+    def subscribe_root_property_changes(self):
+        pass
     def get_active_window_id(self):
         return None
     def get_wm_class(self, wid):

--- a/tests/test_daemon_focus.py
+++ b/tests/test_daemon_focus.py
@@ -168,3 +168,37 @@ def test_run_subscribes_to_property_changes_and_seeds_initial_focus(monkeypatch,
     assert fake.subscribe_property_called, "daemon must subscribe to root property changes"
     assert fake.active_window_queries >= 1, "daemon must query active window at startup"
     assert received == [0xBEEF]
+
+
+def test_initial_focus_query_failure_does_not_abort_startup(monkeypatch, tmp_path):
+    """If the X server returns a malformed/absent _NET_ACTIVE_WINDOW or otherwise
+    raises during the startup query, the daemon must keep starting — the next
+    PropertyNotify will populate focus shortly after, and aborting startup over
+    a single missed property would be a hard regression on every Claude session."""
+    from claude_alerts import daemon as daemon_mod
+
+    fake = _FocusFakeX11()
+
+    def _boom():
+        fake.active_window_queries += 1
+        raise RuntimeError("simulated X11 failure on initial property read")
+
+    fake.get_active_window_id = _boom
+    monkeypatch.setattr(daemon_mod, "X11Client", lambda: fake)
+    d = daemon_mod.Daemon(events_dir=tmp_path / "events", config=Config())
+
+    received = []
+    real = d.overlay.set_focused_window
+
+    def _spy(wid):
+        received.append(wid)
+        return real(wid)
+    d.overlay.set_focused_window = _spy
+
+    d._stop.set()
+    # No exception: run() must swallow the initial focus failure and proceed.
+    d.run()
+
+    assert fake.active_window_queries == 1, "daemon must still attempt the initial query"
+    assert received == [], "set_focused_window must NOT be called when the query raises"
+    assert fake.subscribe_property_called, "subscribe must still happen after a failed query"

--- a/tests/test_daemon_focus.py
+++ b/tests/test_daemon_focus.py
@@ -1,0 +1,170 @@
+"""Verifies the daemon subscribes to _NET_ACTIVE_WINDOW PropertyNotify on
+root, dispatches focus updates to the OverlayManager, and seeds the initial
+focus at startup."""
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+from Xlib import X
+
+from claude_alerts.config import Config
+
+
+_NET_ACTIVE_WINDOW_ATOM = 0xABCD
+
+
+class _FocusFakeX11:
+    """Just enough X11Client surface for Daemon.__init__ and _handle_x_event."""
+
+    def __init__(self, active_window_id: Optional[int] = None) -> None:
+        self.screen = None
+        self._NET_ACTIVE_WINDOW = _NET_ACTIVE_WINDOW_ATOM
+        self._NET_CLIENT_LIST = 0
+        self._NET_WM_STATE = 0
+        self._GTK_FRAME_EXTENTS = 0
+        self._NET_WM_WINDOW_TYPE = 0
+        self._NET_WM_WINDOW_TYPE_UTILITY = 0
+        self._NET_WM_STATE_SKIP_TASKBAR = 0
+        self._NET_WM_STATE_SKIP_PAGER = 0
+        self._MOTIF_WM_HINTS = 0
+        # Mimic python-xlib root: anything with a unique .id we can compare to.
+        self.root = type("R", (), {"id": 0xDEAD})()
+        self._active_window_id = active_window_id
+        self.subscribe_substructure_called = False
+        self.subscribe_property_called = False
+        self.flushed = 0
+        self.active_window_queries = 0
+
+    def fileno(self):
+        return -1
+
+    def flush(self):
+        self.flushed += 1
+
+    def subscribe_root_substructure(self):
+        self.subscribe_substructure_called = True
+
+    def subscribe_root_property_changes(self):
+        self.subscribe_property_called = True
+
+    def get_active_window_id(self):
+        self.active_window_queries += 1
+        return self._active_window_id
+
+    def get_wm_class(self, wid):
+        return ""
+
+    def get_geometry(self, wid):
+        return None
+
+    def get_visible_geometry(self, wid):
+        return None
+
+    def get_frame_window_id(self, wid):
+        return None
+
+    def list_top_level_windows(self):
+        return []
+
+    def pending_events(self):
+        return 0
+
+    def next_event(self):
+        return None
+
+
+@pytest.fixture
+def daemon_with_focus_x11(monkeypatch, tmp_path):
+    from claude_alerts import daemon as daemon_mod
+
+    fake = _FocusFakeX11(active_window_id=0x1111)
+    monkeypatch.setattr(daemon_mod, "X11Client", lambda: fake)
+    d = daemon_mod.Daemon(events_dir=tmp_path / "events", config=Config())
+
+    # Spy on the overlay manager's set_focused_window.
+    received = []
+    real = d.overlay.set_focused_window
+
+    def _spy(wid):
+        received.append(wid)
+        return real(wid)
+    d.overlay.set_focused_window = _spy
+    return d, fake, received
+
+
+def _make_property_notify(window, atom):
+    """Synthesize a python-xlib-shaped PropertyNotify event."""
+    class _Evt:
+        type = X.PropertyNotify
+
+    e = _Evt()
+    e.window = window
+    e.atom = atom
+    return e
+
+
+def test_property_notify_for_net_active_window_dispatches_focus(daemon_with_focus_x11):
+    daemon, fake, received = daemon_with_focus_x11
+
+    fake._active_window_id = 0xC0FFEE
+    evt = _make_property_notify(fake.root, fake._NET_ACTIVE_WINDOW)
+    daemon._handle_x_event(evt)
+
+    assert received == [0xC0FFEE]
+
+
+def test_property_notify_for_unrelated_atom_is_ignored(daemon_with_focus_x11):
+    daemon, fake, received = daemon_with_focus_x11
+
+    other_atom = fake._NET_ACTIVE_WINDOW + 99
+    evt = _make_property_notify(fake.root, other_atom)
+    daemon._handle_x_event(evt)
+
+    assert received == []
+
+
+def test_property_notify_for_non_root_window_is_ignored(daemon_with_focus_x11):
+    daemon, fake, received = daemon_with_focus_x11
+
+    other_window = type("R", (), {"id": 0xBAD})()
+    evt = _make_property_notify(other_window, fake._NET_ACTIVE_WINDOW)
+    daemon._handle_x_event(evt)
+
+    assert received == []
+
+
+def test_focus_dispatch_passes_none_when_active_window_missing(daemon_with_focus_x11):
+    daemon, fake, received = daemon_with_focus_x11
+
+    fake._active_window_id = None
+    evt = _make_property_notify(fake.root, fake._NET_ACTIVE_WINDOW)
+    daemon._handle_x_event(evt)
+
+    assert received == [None]
+
+
+def test_run_subscribes_to_property_changes_and_seeds_initial_focus(monkeypatch, tmp_path):
+    """Daemon.run() must subscribe to property changes on root AND query the
+    initial focus so the first paint after restart reflects reality."""
+    from claude_alerts import daemon as daemon_mod
+
+    fake = _FocusFakeX11(active_window_id=0xBEEF)
+    monkeypatch.setattr(daemon_mod, "X11Client", lambda: fake)
+    d = daemon_mod.Daemon(events_dir=tmp_path / "events", config=Config())
+
+    received = []
+    real = d.overlay.set_focused_window
+
+    def _spy(wid):
+        received.append(wid)
+        return real(wid)
+    d.overlay.set_focused_window = _spy
+
+    # Stop the daemon immediately so run() does the startup work and exits.
+    d._stop.set()
+    d.run()
+
+    assert fake.subscribe_property_called, "daemon must subscribe to root property changes"
+    assert fake.active_window_queries >= 1, "daemon must query active window at startup"
+    assert received == [0xBEEF]

--- a/tests/test_daemon_threading.py
+++ b/tests/test_daemon_threading.py
@@ -55,6 +55,8 @@ def tracking_daemon(monkeypatch, tmp_path):
             return []
         def subscribe_root_substructure(self):
             call_threads.append(("subscribe_root_substructure", threading.current_thread().name))
+        def subscribe_root_property_changes(self):
+            call_threads.append(("subscribe_root_property_changes", threading.current_thread().name))
         def pending_events(self):
             return 0
         def next_event(self):

--- a/tests/test_e2e_xvfb.py
+++ b/tests/test_e2e_xvfb.py
@@ -81,6 +81,92 @@ def _wait(predicate, timeout=3.0):
     return False
 
 
+def _set_active_window(disp, root, win_id):
+    from Xlib import Xatom
+    NET_ACTIVE_WINDOW = disp.intern_atom("_NET_ACTIVE_WINDOW")
+    root.change_property(NET_ACTIVE_WINDOW, Xatom.WINDOW, 32, [win_id])
+    disp.flush()
+
+
+def test_focus_modulation_recolours_overlay_via_property_notify(xvfb, tmp_path):
+    """End-to-end focus-modulation tracer bullet:
+    bind a session → focus the bound terminal → daemon paints emissive →
+    move focus to a different window → daemon paints dim.
+    """
+    from Xlib import X, display
+
+    fake_disp, fake_win = _spawn_fake_terminal_window()
+
+    # Spawn a second, non-Claude window so we have somewhere to move focus.
+    other_disp = display.Display()
+    other_screen = other_disp.screen()
+    other_win = other_screen.root.create_window(
+        500, 500, 200, 150, 1,
+        other_screen.root_depth,
+        X.InputOutput,
+        X.CopyFromParent,
+        background_pixel=other_screen.white_pixel,
+        event_mask=X.ExposureMask,
+    )
+    other_win.set_wm_class("not-a-terminal", "Other")
+    other_win.set_wm_name("other window")
+    other_win.map()
+    other_disp.flush()
+
+    events_dir = tmp_path / "events"
+    cfg = Config()
+    daemon = Daemon(events_dir=events_dir, config=cfg)
+    t = threading.Thread(target=daemon.run, daemon=True)
+    t.start()
+    try:
+        # SessionStart + UserPromptSubmit so the binder grabs the fake terminal.
+        _drop_event(
+            events_dir,
+            {
+                "event": "SessionStart", "session_id": "s1",
+                "cwd": "/proj", "claude_pid": 1, "timestamp": 1.0,
+            },
+            "01-start",
+        )
+        _drop_event(
+            events_dir,
+            {
+                "event": "UserPromptSubmit", "session_id": "s1",
+                "cwd": "/proj", "claude_pid": 1, "timestamp": 2.0,
+            },
+            "02-prompt",
+        )
+        assert _wait(lambda: daemon.overlay.has_overlay("s1"))
+
+        from claude_alerts.colors import dim_hex
+        from claude_alerts.overlay import _rgb_to_pixel, hex_to_rgb
+        green = _rgb_to_pixel(hex_to_rgb(cfg.color_working))
+        green_dim = _rgb_to_pixel(hex_to_rgb(dim_hex(cfg.color_working, 0.25)))
+
+        # Focus on the bound terminal — overlay must paint emissive green.
+        _set_active_window(fake_disp, fake_disp.screen().root, fake_win.id)
+        assert _wait(lambda: daemon.overlay._overlays["s1"].color_pixel == green)
+
+        # Focus moves to the other (non-Claude) window — overlay must dim.
+        _set_active_window(fake_disp, fake_disp.screen().root, other_win.id)
+        assert _wait(lambda: daemon.overlay._overlays["s1"].color_pixel == green_dim)
+    finally:
+        daemon.stop()
+        t.join(timeout=2)
+        try:
+            fake_win.destroy()
+            fake_disp.flush()
+            fake_disp.close()
+        except Exception:
+            pass
+        try:
+            other_win.destroy()
+            other_disp.flush()
+            other_disp.close()
+        except Exception:
+            pass
+
+
 def test_daemon_binds_overlay_and_changes_color(xvfb, tmp_path):
     fake_disp, fake_win = _spawn_fake_terminal_window()
 

--- a/tests/test_overlay_smoke.py
+++ b/tests/test_overlay_smoke.py
@@ -68,6 +68,7 @@ class _RecordingX11:
 class _FakeOverlayWindow:
     """Stand-in for the real X11-touching _OverlayWindow."""
     instances: list["_FakeOverlayWindow"] = []
+    _next_id = 0xFA00  # auto-increment window_id so the manager's self-filter has something to match
 
     def __init__(self, x11, geo, color_pixel, thickness, transient_for_window_id=None):
         self.geo = geo
@@ -76,6 +77,8 @@ class _FakeOverlayWindow:
         self.transient_for_window_id = transient_for_window_id
         self.update_calls: list[Geometry] = []
         self.destroyed = False
+        self.window_id = _FakeOverlayWindow._next_id
+        _FakeOverlayWindow._next_id += 1
         _FakeOverlayWindow.instances.append(self)
 
     def update_geometry(self, geo):
@@ -442,3 +445,216 @@ def test_color_for_elicitation_with_background_active_is_red(monkeypatch):
     assert s.background_active is True
     assert s.last_event == "Elicitation"
     assert mgr.color_for(s) == _red_pixel()
+
+
+# --- focus modulation tests --------------------------------------------------
+
+
+def _green_dim_pixel():
+    from claude_alerts.colors import dim_hex
+    from claude_alerts.overlay import _rgb_to_pixel, hex_to_rgb
+    return _rgb_to_pixel(hex_to_rgb(dim_hex(Config().color_working, 0.25)))
+
+
+def _red_dim_pixel():
+    from claude_alerts.colors import dim_hex
+    from claude_alerts.overlay import _rgb_to_pixel, hex_to_rgb
+    return _rgb_to_pixel(hex_to_rgb(dim_hex(Config().color_waiting, 0.25)))
+
+
+def _bind_session(store, sid, frame_wid, client_wid):
+    store.set_bound_window(sid, frame_wid, client_window_id=client_wid)
+
+
+def test_unfocused_bound_session_paints_dim_green_when_working(monkeypatch):
+    """A WORKING session whose client window is not the active window paints
+    the derived 0.25-ratio dim of the working colour."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    # Focus is on something else — the dashboard window, say.
+    mgr.set_focused_window(0xDDDD)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_dim_pixel()
+
+
+def test_unfocused_bound_session_paints_dim_red_when_waiting(monkeypatch):
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="Stop", session_id="s1", cwd="/p", claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(0xDDDD)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _red_dim_pixel()
+
+
+def test_focused_bound_session_paints_full_brightness(monkeypatch):
+    """When focus moves to the bound session's client window, its overlay
+    paints the emissive colour."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_pixel()
+
+
+def test_focus_change_between_two_sessions_dims_previous_lights_new(monkeypatch):
+    """Focus moving from session A's window to session B's window should
+    dim A and light B in a single update."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    # Session A
+    store.apply_event(ClaudeEvent(
+        event="SessionStart", session_id="sA", cwd="/p", claude_pid=1, timestamp=1.0,
+    ))
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="sA", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "sA", 0xAA00, 0xAA01)
+    # Session B
+    store.apply_event(ClaudeEvent(
+        event="SessionStart", session_id="sB", cwd="/p", claude_pid=2, timestamp=3.0,
+    ))
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="sB", cwd="/p",
+        claude_pid=2, timestamp=4.0,
+    ))
+    _bind_session(store, "sB", 0xBB00, 0xBB01)
+
+    # Visible geometry resolves only for FRAME_WID/CLIENT_WID in _RecordingX11;
+    # patch the recording fake to also resolve our test ids.
+    # Our _RecordingX11 returns None for unknown wids — let's monkeypatch.
+    # Easier: extend the fake on the fly.
+    from claude_alerts.x11 import Geometry as _Geo
+    mgr.x11.get_visible_geometry = lambda wid: _Geo(0, 0, 100, 100) if wid in (0xAA01, 0xBB01) else None
+    # Force a re-sync now that geometry resolves.
+    mgr.refresh_all_geometry()
+    mgr._sync_one(store.get("sA"))
+    mgr._sync_one(store.get("sB"))
+
+    # Focus on A.
+    mgr.set_focused_window(0xAA01)
+    overlays_by_sid = {s.session_id: ov for s, ov in zip(store.all(), _FakeOverlayWindow.instances) if False}  # noqa: unused
+
+    # Manually map by inspecting overlays via their position in instances:
+    # Sessions get their _FakeOverlayWindow on first _sync_one. The instance
+    # list ordering depends on insertion; pull them from the manager directly.
+    ov_a = mgr._overlays["sA"]
+    ov_b = mgr._overlays["sB"]
+    assert ov_a.color_pixel == _green_pixel()
+    assert ov_b.color_pixel == _green_dim_pixel()
+
+    # Focus moves to B.
+    mgr.set_focused_window(0xBB01)
+    assert ov_a.color_pixel == _green_dim_pixel()
+    assert ov_b.color_pixel == _green_pixel()
+
+
+def test_focus_on_non_claude_window_dims_all(monkeypatch):
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_pixel()
+    # Focus moves to a totally unrelated window.
+    mgr.set_focused_window(0xDDDD)
+    assert overlay.color_pixel == _green_dim_pixel()
+
+
+def test_focus_none_dims_all(monkeypatch):
+    """No active window at all (rare, but possible)."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    mgr.set_focused_window(None)
+    assert overlay.color_pixel == _green_dim_pixel()
+
+
+def test_set_focused_window_ignores_our_own_overlay_windows(monkeypatch):
+    """Defensive filter: a focus event whose target is one of our overlay
+    windows must not displace the real focus state."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_pixel()
+
+    # Now an event arrives saying our own overlay is the active window.
+    mgr.set_focused_window(overlay.window_id)
+    # Focus must NOT change — the bound session is still focused.
+    assert overlay.color_pixel == _green_pixel()
+
+
+def test_duplicate_focus_events_are_idempotent(monkeypatch):
+    """Two PropertyNotify events for the same active window should not
+    cause two repaints (coalescing)."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    # Track set_color calls.
+    initial_color = overlay.color_pixel
+    paint_count = [0]
+    real_set_color = overlay.set_color
+
+    def _counting(pixel):
+        paint_count[0] += 1
+        real_set_color(pixel)
+    overlay.set_color = _counting
+
+    mgr.set_focused_window(CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    assert paint_count[0] == 0
+    assert overlay.color_pixel == initial_color
+
+
+def test_overlay_destroyed_removes_from_self_filter(monkeypatch):
+    """When a session unbinds, its overlay window id leaves the self-filter
+    set so that wid is freed up for legitimate focus tracking later."""
+    mgr, store, _ = _make_manager(monkeypatch)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    overlay_wid = overlay.window_id
+    store.set_bound_window("s1", None)
+    assert overlay.destroyed
+    # Now a focus event for that ex-overlay-id should pass through (not
+    # silently swallowed) — though there's nothing bound to repaint, the
+    # internal state should update.
+    assert overlay_wid not in mgr._overlay_window_ids


### PR DESCRIPTION
Closes #11.

## Summary

- Borders now dim to 1/4 intensity when their bound terminal is not the active window. Focus moves between Claude windows or to a non-Claude window and every overlay repaints in a single mainloop tick.
- New pure module `claude_alerts/colors.py` owns `dim_hex` and `pick_color_pixel`; the overlay manager is a thin wrapper around them.
- Daemon subscribes to PropertyNotify on root, seeds the initial focus at startup, and ignores active-window events targeting one of our own overlays (defensive self-filter).

## Test plan

- [x] `pytest` — 265 passed, 2 skipped (Xvfb e2e tests skipped in sandbox).
- [ ] Run `pytest tests/test_e2e_xvfb.py` on a host with `Xvfb` to confirm the focus-modulation tracer-bullet end-to-end.
- [ ] Smoke check on a real desktop: open two Claude terminals, verify alt-tabbing dims the previous one and lights the new one without flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)