### PR TITLE
#12 config overrides for unfocused border colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Optional — defaults are baked in. Override at
 [colors]
 working = "#22c55e"
 waiting = "#ef4444"
+# Optional. When omitted, the unfocused (dim) variants are derived from the
+# focused colours by multiplying each RGB channel by 0.25. Set them
+# explicitly if the derived dim is too aggressive (or not aggressive enough)
+# for your terminal background.
+# working_unfocused = "#083117"
+# waiting_unfocused = "#3b1111"
 
 [border]
 thickness_px = 4

--- a/claude_alerts/config.py
+++ b/claude_alerts/config.py
@@ -20,6 +20,10 @@ class ConfigError(ValueError):
 class Config:
     color_working: str = "#22c55e"
     color_waiting: str = "#ef4444"
+    # When None, the daemon derives the dim variant from the focused colour
+    # via dim_hex(..., 0.25). When set, the configured value is used verbatim.
+    color_working_unfocused: str | None = None
+    color_waiting_unfocused: str | None = None
     border_thickness_px: int = 4
     log_level: str = "INFO"
 
@@ -38,6 +42,22 @@ def _require_int(value, field: str) -> int:
             f"{field} must be an integer, got {type(value).__name__}"
         )
     return value
+
+
+def _require_hex_color(value, field: str) -> str:
+    s = _require_str(value, field)
+    candidate = s.lstrip("#")
+    if len(candidate) != 6:
+        raise ConfigError(
+            f"{field} must be a 6-digit hex color like '#22c55e', got {s!r}"
+        )
+    try:
+        int(candidate, 16)
+    except ValueError as e:
+        raise ConfigError(
+            f"{field} must be a 6-digit hex color like '#22c55e', got {s!r}"
+        ) from e
+    return s
 
 
 def load_config(path: Path) -> Config:
@@ -66,6 +86,14 @@ def load_config(path: Path) -> Config:
         overrides["color_working"] = _require_str(colors["working"], "colors.working")
     if "waiting" in colors:
         overrides["color_waiting"] = _require_str(colors["waiting"], "colors.waiting")
+    if "working_unfocused" in colors:
+        overrides["color_working_unfocused"] = _require_hex_color(
+            colors["working_unfocused"], "colors.working_unfocused"
+        )
+    if "waiting_unfocused" in colors:
+        overrides["color_waiting_unfocused"] = _require_hex_color(
+            colors["waiting_unfocused"], "colors.waiting_unfocused"
+        )
 
     border = data.get("border", {})
     if not isinstance(border, dict):

--- a/claude_alerts/overlay.py
+++ b/claude_alerts/overlay.py
@@ -140,12 +140,18 @@ class OverlayManager:
         self._overlays: dict[str, _OverlayWindow] = {}
         self._working_pixel = _rgb_to_pixel(hex_to_rgb(config.color_working))
         self._waiting_pixel = _rgb_to_pixel(hex_to_rgb(config.color_waiting))
-        self._working_dim_pixel = _rgb_to_pixel(
-            hex_to_rgb(dim_hex(config.color_working, DIM_RATIO))
+        working_dim_hex = (
+            config.color_working_unfocused
+            if config.color_working_unfocused is not None
+            else dim_hex(config.color_working, DIM_RATIO)
         )
-        self._waiting_dim_pixel = _rgb_to_pixel(
-            hex_to_rgb(dim_hex(config.color_waiting, DIM_RATIO))
+        waiting_dim_hex = (
+            config.color_waiting_unfocused
+            if config.color_waiting_unfocused is not None
+            else dim_hex(config.color_waiting, DIM_RATIO)
         )
+        self._working_dim_pixel = _rgb_to_pixel(hex_to_rgb(working_dim_hex))
+        self._waiting_dim_pixel = _rgb_to_pixel(hex_to_rgb(waiting_dim_hex))
         # Currently-focused client window id (per _NET_ACTIVE_WINDOW). None
         # when no Claude or other window is focused; daemon queries the
         # X server at startup so this reflects reality before the first paint.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,3 +109,73 @@ def test_wrong_type_debug_section_raises(tmp_path):
     p.write_text('debug = "not a table"\n')
     with pytest.raises(ConfigError, match="debug must be a TOML table"):
         load_config(p)
+
+
+# ---------- unfocused border colour overrides (#12) ----------
+#
+# Four matrix cells: both keys present, only working_unfocused, only
+# waiting_unfocused, neither. Plus malformed-value cases.
+
+
+def test_unfocused_neither_present_defaults_to_none(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nworking = "#22c55e"\nwaiting = "#ef4444"\n')
+    cfg = load_config(p)
+    assert cfg.color_working_unfocused is None
+    assert cfg.color_waiting_unfocused is None
+
+
+def test_unfocused_only_working_present(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nworking_unfocused = "#0a0a0a"\n')
+    cfg = load_config(p)
+    assert cfg.color_working_unfocused == "#0a0a0a"
+    assert cfg.color_waiting_unfocused is None
+
+
+def test_unfocused_only_waiting_present(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nwaiting_unfocused = "#1b0000"\n')
+    cfg = load_config(p)
+    assert cfg.color_working_unfocused is None
+    assert cfg.color_waiting_unfocused == "#1b0000"
+
+
+def test_unfocused_both_present(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[colors]\n'
+        'working_unfocused = "#0a0a0a"\n'
+        'waiting_unfocused = "#1b0000"\n'
+    )
+    cfg = load_config(p)
+    assert cfg.color_working_unfocused == "#0a0a0a"
+    assert cfg.color_waiting_unfocused == "#1b0000"
+
+
+def test_unfocused_working_non_string_raises(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nworking_unfocused = 42\n')
+    with pytest.raises(ConfigError, match="colors.working_unfocused"):
+        load_config(p)
+
+
+def test_unfocused_waiting_non_string_raises(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nwaiting_unfocused = true\n')
+    with pytest.raises(ConfigError, match="colors.waiting_unfocused"):
+        load_config(p)
+
+
+def test_unfocused_working_bad_hex_raises(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nworking_unfocused = "#zz0000"\n')
+    with pytest.raises(ConfigError, match="colors.working_unfocused"):
+        load_config(p)
+
+
+def test_unfocused_waiting_wrong_length_raises(tmp_path):
+    p = tmp_path / "config.toml"
+    p.write_text('[colors]\nwaiting_unfocused = "#abcde"\n')
+    with pytest.raises(ConfigError, match="colors.waiting_unfocused"):
+        load_config(p)

--- a/tests/test_overlay_smoke.py
+++ b/tests/test_overlay_smoke.py
@@ -658,3 +658,80 @@ def test_overlay_destroyed_removes_from_self_filter(monkeypatch):
     # silently swallowed) — though there's nothing bound to repaint, the
     # internal state should update.
     assert overlay_wid not in mgr._overlay_window_ids
+
+
+# --- #12: configured unfocused colour overrides ----------------------------
+
+
+def _make_manager_with_config(monkeypatch, cfg):
+    from claude_alerts import overlay as overlay_mod
+    _FakeOverlayWindow.instances = []
+    monkeypatch.setattr(overlay_mod, "_OverlayWindow", _FakeOverlayWindow)
+    store = SessionStore()
+    x11 = _RecordingX11()
+    mgr = overlay_mod.OverlayManager(x11, store, cfg)
+    return mgr, store, x11
+
+
+def test_working_unfocused_override_replaces_derived_dim(monkeypatch):
+    """When color_working_unfocused is set, the dim pixel is the configured
+    value verbatim, not dim_hex(color_working, 0.25)."""
+    from claude_alerts.overlay import _rgb_to_pixel, hex_to_rgb
+    cfg = Config(color_working_unfocused="#0a0a0a")
+    mgr, store, _ = _make_manager_with_config(monkeypatch, cfg)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(0xDDDD)  # unfocused
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _rgb_to_pixel(hex_to_rgb("#0a0a0a"))
+
+
+def test_waiting_unfocused_override_replaces_derived_dim(monkeypatch):
+    from claude_alerts.overlay import _rgb_to_pixel, hex_to_rgb
+    cfg = Config(color_waiting_unfocused="#1b0000")
+    mgr, store, _ = _make_manager_with_config(monkeypatch, cfg)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="Stop", session_id="s1", cwd="/p", claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(0xDDDD)  # unfocused
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _rgb_to_pixel(hex_to_rgb("#1b0000"))
+
+
+def test_overrides_do_not_affect_focused_emissive_paint(monkeypatch):
+    """Override only touches the dim path; focused windows still paint the
+    configured (or default) emissive colour."""
+    cfg = Config(
+        color_working_unfocused="#0a0a0a",
+        color_waiting_unfocused="#1b0000",
+    )
+    mgr, store, _ = _make_manager_with_config(monkeypatch, cfg)
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(CLIENT_WID)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_pixel()
+
+
+def test_unfocused_defaults_to_derived_when_overrides_absent(monkeypatch):
+    """No override config => exact same derived dim pixels as before #12."""
+    mgr, store, _ = _make_manager_with_config(monkeypatch, Config())
+    _start_session(store)
+    store.apply_event(ClaudeEvent(
+        event="UserPromptSubmit", session_id="s1", cwd="/p",
+        claude_pid=1, timestamp=2.0,
+    ))
+    _bind_session(store, "s1", FRAME_WID, CLIENT_WID)
+    mgr.set_focused_window(0xDDDD)
+    overlay = _FakeOverlayWindow.instances[0]
+    assert overlay.color_pixel == _green_dim_pixel()


### PR DESCRIPTION
## Summary

- Adds two optional `[colors]` keys — `working_unfocused` and `waiting_unfocused` — that override the derived dim border colour for each state.
- When omitted, the dim variant continues to be derived from the focused colour by multiplying each RGB channel by `0.25` (the #11 default).
- Malformed override values (non-string, bad hex, wrong length) are rejected at config-load time with a clear `ConfigError` naming the field, so the failure mode is a startup error pointing at the right key — not a cryptic Xlib failure later.

Stacked on top of #14 — the `feat/11-focus-modulated-borders` branch is the base because #12 wires into the dim-pixel computation that #11 introduced. Once #14 merges, this PR rebases onto main with no surface-area collision.

## Test plan

- [x] `pytest` from repo root: 277 passed, 2 skipped (was 265 passed before this branch — 8 config tests + 4 overlay tests added).
- [x] Config matrix: tests cover both keys present, only `working_unfocused` present, only `waiting_unfocused` present, neither present.
- [x] Validation: tests cover non-string, bad hex digits, and wrong-length values for both keys.
- [x] Overlay: tests cover override-replaces-derived for both states, focused emissive paint untouched by overrides, and defaults-match-#11-when-overrides-absent.
- [ ] Manual end-to-end: deferred — needs an active X11 session with multiple Claude terminals to eyeball the dim contrast against a real terminal background. The pure-function plumbing is fully covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)